### PR TITLE
Group projects section by project with per-repo cards

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -4,14 +4,74 @@ import aiAgentImg from '../assets/ai-agent.png';
 import priceForecastImg from '../assets/price-forecast.png';
 import favoritesImg from '../assets/favorites.png';
 
+export const PROJECT_GROUPS = [
+  {
+    name: 'GasAgent.ai',
+    tagline: 'Fuel & EV finder with a multi-step AI agent',
+    icon: 'fuel',
+    description:
+      'A cross-platform mobile app that helps drivers find fuel and charging, track prices, and get short-term forecasts. It includes a built-in AI agent that plans and runs multi-step lookups on its own rather than answering from a script. A full-stack learning project built from a React Native client, a FastAPI backend, third-party data, and a bounded tool-calling agent. Not intended for production use.',
+    stack: ['React Native', 'TypeScript', 'Python', 'FastAPI', 'LLM Tool-Calling'],
+    repos: [{ label: 'gasagent-ai', url: 'https://github.com/Girujan1998/gasagent-ai' }],
+    parts: [
+      {
+        slug: 'gasagent-frontend',
+        kind: 'Mobile app',
+        blurb:
+          'React Native (iOS and Android) client in TypeScript. Gas and EV search, favorites, price forecasts, and the agent chat all share one location and one set of result cards.',
+        stack: ['React Native', 'TypeScript', 'Jest'],
+        github: 'https://github.com/Girujan1998/gasagent-ai/tree/main/mobile',
+      },
+      {
+        slug: 'gasagent-backend',
+        kind: 'API backend',
+        blurb:
+          "FastAPI REST API covering station search, deterministic fuel-cost math, price forecasting, and the agent's five-tool loop over an LLM API. Filtering and ranking happen in code.",
+        stack: ['Python', 'FastAPI', 'pytest'],
+        github: 'https://github.com/Girujan1998/gasagent-ai/tree/main/backend',
+      },
+    ],
+  },
+  {
+    name: 'EyeGuide',
+    tagline: 'Indoor navigation for the visually impaired',
+    icon: 'white-cane',
+    description:
+      'A React Native app that lets visually impaired users navigate indoor spaces independently, with minimal hardware and no indoor GPS. Volunteers map buildings from Android devices; users pick a destination and get audio-guided, turn-by-turn navigation from pedometer step counting and magnetometer bearing. An optional Arduino Nano BLE lidar module adds haptic obstacle alerts within 2 metres.',
+    stack: ['React Native', 'JavaScript', 'Django', 'PostgreSQL', 'Arduino'],
+    repos: [
+      { label: 'EyeGuide', url: 'https://github.com/Girujan1998/EyeGuide' },
+      { label: 'EyeGuide-backend', url: 'https://github.com/Girujan1998/EyeGuide-backend' },
+    ],
+    parts: [
+      {
+        slug: 'eyeguide-frontend',
+        kind: 'Frontend',
+        blurb:
+          'React Native app with full Android TalkBack support. Pedometer and magnetometer navigation, remote building-map creation, and optional lidar obstacle detection.',
+        stack: ['React Native', 'Java', 'C++', 'Arduino'],
+        github: 'https://github.com/Girujan1998/EyeGuide',
+      },
+      {
+        slug: 'eyeguide-backend',
+        kind: 'Backend',
+        blurb:
+          'Django REST API for building maps, GPS path coordinates, and route data consumed by the app. PostgreSQL via pgAdmin, with NGROK tunneling for on-device access during development.',
+        stack: ['Python', 'Django', 'PostgreSQL'],
+        github: 'https://github.com/Girujan1998/EyeGuide-backend',
+      },
+    ],
+  },
+];
+
 export const PROJECTS = [
   {
     slug: 'gasagent-frontend',
     name: 'GasAgent.ai — Frontend',
     tagline: 'Cross-platform mobile app for finding fuel and charging',
     overview: [
-      'GasAgent.ai is a cross-platform React Native app (iOS and Android) that helps drivers find fuel and charging options, track prices, and get short-term price forecasts — with a built-in AI agent that plans and executes multi-step lookups on its own rather than answering from a script.',
-      'The mobile client is written in TypeScript and consumes a Python (FastAPI) backend. Search results — gas stations, EV chargers, and forecasts — render as rich cards that are reused across the dedicated search tabs and inline in the AI agent chat. Location shared once carries across every tab instead of being re-requested.',
+      'GasAgent.ai is a cross-platform React Native app (iOS and Android) that helps drivers find fuel and charging options, track prices, and get short-term price forecasts. It includes a built-in AI agent that plans and executes multi-step lookups on its own rather than answering from a script.',
+      'The mobile client is written in TypeScript and consumes a Python (FastAPI) backend. Search results for gas stations, EV chargers, and forecasts render as rich cards that are reused across the dedicated search tabs and inline in the AI agent chat. Location shared once carries across every tab instead of being re-requested.',
       'This is a personal portfolio and learning project, built to practice full-stack mobile development: a React Native client, a Python API backend, third-party data integration, and an AI agent with tool-calling. It runs on free-tier hosting and public data sources and is not intended for production use.',
     ],
     features: [
@@ -20,7 +80,7 @@ export const PROJECTS = [
       'Conversational AI agent that chains multiple lookups to answer a single goal',
       'Short-term local gas price forecasting',
       'Favorites: save stations from results, reorder them, and refresh prices later',
-      'Shared location state across all tabs — share once, use everywhere',
+      'Shared location state across all tabs, so you share once and use it everywhere',
       'Rich station result cards reused across search tabs and the agent chat',
       'Jest test suite for the mobile app',
     ],
@@ -43,13 +103,13 @@ export const PROJECTS = [
     tagline: 'FastAPI service with a bounded tool-calling AI agent',
     overview: [
       'The GasAgent.ai backend is a FastAPI (Python) REST API that powers the mobile app. It handles gas and EV station search, fuel-cost arithmetic, and gas price forecasting, integrating a mix of free public and third-party data sources behind a single clean API surface.',
-      'Its centrepiece is an AI agent implemented as a bounded tool-calling loop over a large-language-model API. Given a goal like "what would it cost to fill up at the cheapest station near me?", the agent decides which tools to call and in what order, feeds each result into the next step, and continues — up to a bounded number of steps — until it can give a grounded answer.',
-      'The agent has five tools: gas station search, EV charging search, combined gas + EV search, fuel-cost arithmetic, and price forecasting. All filtering, sorting, ranking, and math happen in code — the model never reasons over raw result lists or does arithmetic itself; it only decides which tools to call and how to phrase the answer.',
+      'Its centrepiece is an AI agent implemented as a bounded tool-calling loop over a large-language-model API. Given a goal like "what would it cost to fill up at the cheapest station near me?", the agent decides which tools to call and in what order, feeds each result into the next step, and continues, up to a bounded number of steps, until it can give a grounded answer.',
+      'The agent has five tools: gas station search, EV charging search, combined gas and EV search, fuel-cost arithmetic, and price forecasting. All filtering, sorting, ranking, and math happen in code. The model never reasons over raw result lists or does arithmetic itself; it only decides which tools to call and how to phrase the answer.',
     ],
     features: [
       'REST API for gas station, EV charging, and combined station search',
       'Bounded tool-calling agent loop over an LLM API with five code-backed tools',
-      'Deterministic fuel-cost arithmetic — computed in code, never by the model',
+      'Deterministic fuel-cost arithmetic, computed in code, never by the model',
       'Next-day gas price forecasting combining local average and regional trend',
       'Third-party and public data source integration behind a unified API',
       'Graceful degradation when optional API keys are absent',
@@ -66,9 +126,9 @@ export const PROJECTS = [
     name: 'EyeGuide — Frontend',
     tagline: 'Indoor navigation mobile app for the visually impaired',
     overview: [
-      'EyeGuide is a React Native mobile application designed to enable visually impaired users to navigate indoor spaces independently — with minimal hardware and at an affordable cost.',
+      'EyeGuide is a React Native mobile application designed to enable visually impaired users to navigate indoor spaces independently, with minimal hardware and at an affordable cost.',
       'Building administrators or volunteers create detailed indoor maps remotely using Android devices. Visually impaired users then launch EyeGuide, select a destination, and receive real-time audio-guided turn-by-turn navigation through the building. The app is built with full Android TalkBack accessibility support throughout.',
-      'Navigation is powered by pedometer-based step counting for distance tracking and magnetometer bearing detection for directional guidance — eliminating any dependency on indoor GPS. An optional custom-built Arduino Nano BLE lidar module can be mounted to the device; it vibrates to alert the user when an obstacle is detected within 2 metres.',
+      'Navigation is powered by pedometer-based step counting for distance tracking and magnetometer bearing detection for directional guidance, eliminating any dependency on indoor GPS. An optional custom-built Arduino Nano BLE lidar module can be mounted to the device; it vibrates to alert the user when an obstacle is detected within 2 metres.',
     ],
     features: [
       'Audio-guided turn-by-turn indoor navigation without internet or GPS',

--- a/src/sections/Projects.css
+++ b/src/sections/Projects.css
@@ -2,53 +2,144 @@
   background-color: var(--surface);
 }
 
-.projects-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
+.project-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
 }
 
-/* ── Card ── */
-.project-card {
+/* ── Group panel ── */
+.project-group {
   background-color: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 26px;
+  padding: 28px;
+}
+
+.pg-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.pg-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  color: var(--accent);
+  background-color: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.18);
+}
+
+.pg-heading {
+  flex: 1;
+  min-width: 0;
+}
+
+.pg-name {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.pg-tagline {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.pg-repos-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.pg-repo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-muted);
+  border: 1px solid var(--border-hover);
+  border-radius: 20px;
+  padding: 6px 13px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.pg-repo:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.pg-description {
+  font-size: 14.5px;
+  color: var(--text-muted);
+  line-height: 1.75;
+  margin-bottom: 16px;
+  max-width: 70ch;
+}
+
+.pg-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+/* ── Repo sub-cards ── */
+.pg-parts {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.part-card {
   display: flex;
   flex-direction: column;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 18px 16px;
   cursor: pointer;
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.project-card:hover {
-  transform: translateY(-5px);
+.part-card:hover {
+  transform: translateY(-3px);
   border-color: rgba(88, 166, 255, 0.35);
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
 }
 
-.project-card-top {
+.part-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 18px;
+  margin-bottom: 9px;
 }
 
-.project-icon {
-  color: var(--accent);
-  display: flex;
-  opacity: 0.9;
-}
-
-.project-links {
-  display: flex;
-  gap: 6px;
+.part-kind {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .proj-link {
   color: var(--text-subtle);
   display: flex;
   align-items: center;
-  padding: 5px;
+  padding: 4px;
   border-radius: 4px;
   transition: color 0.2s;
 }
@@ -57,52 +148,50 @@
   color: var(--text);
 }
 
-/* ── Content ── */
-.project-name {
-  font-family: var(--font-mono);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 10px;
-}
-
-.project-description {
-  font-size: 14px;
+.part-blurb {
+  font-size: 12.75px;
   color: var(--text-muted);
-  line-height: 1.7;
+  line-height: 1.65;
   flex: 1;
-  margin-bottom: 20px;
+  margin-bottom: 14px;
 }
 
-.project-stack {
+.part-stack {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: auto;
-  margin-bottom: 16px;
+  gap: 5px;
+  margin-bottom: 13px;
 }
 
-.project-cta {
+.part-cta {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--accent);
   letter-spacing: 0.04em;
+  margin-top: auto;
   transition: letter-spacing 0.2s ease;
 }
 
-.project-card:hover .project-cta {
+.part-card:hover .part-cta {
   letter-spacing: 0.08em;
 }
 
-/* ── Responsive ── */
-@media (max-width: 960px) {
-  .projects-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+/* ── Small tag variant ── */
+.tag.sm {
+  font-size: 10.5px;
+  padding: 2px 8px;
+  background-color: transparent;
+  color: var(--text-muted);
+  border-color: var(--border-hover);
 }
 
-@media (max-width: 560px) {
-  .projects-grid {
+/* ── Responsive ── */
+@media (max-width: 720px) {
+  .project-group {
+    padding: 20px;
+  }
+
+  .pg-parts {
     grid-template-columns: 1fr;
   }
 }

--- a/src/sections/Projects.js
+++ b/src/sections/Projects.js
@@ -1,19 +1,37 @@
 import { useNavigate } from 'react-router-dom';
-import { PROJECTS } from '../data/projects';
+import { PROJECT_GROUPS } from '../data/projects';
 import './Projects.css';
 
-function IconCode() {
+function IconFuel() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="16 18 22 12 16 6" />
-      <polyline points="8 6 2 12 8 18" />
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="3" y1="22" x2="15" y2="22" />
+      <line x1="4" y1="9" x2="14" y2="9" />
+      <path d="M14 22V4a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v18" />
+      <path d="M14 13h2a2 2 0 0 1 2 2v2a2 2 0 0 0 2 2 2 2 0 0 0 2-2V9.83a2 2 0 0 0-.59-1.42L18 5" />
     </svg>
   );
 }
 
+function IconWhiteCane() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="9" cy="4" r="1.9" />
+      <path d="M9 6.2V13" />
+      <path d="M9 8 6.2 10.5" />
+      <path d="M9 8l2.8 3" />
+      <path d="M9 13l-2.4 7.5" />
+      <path d="M9 13l2.4 3.5-0.4 4" />
+      <path d="M11.8 11 19 21" strokeWidth="1.15" />
+    </svg>
+  );
+}
+
+const ICONS = { fuel: IconFuel, 'white-cane': IconWhiteCane };
+
 function IconGitHub() {
   return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
     </svg>
   );
@@ -29,46 +47,87 @@ function Projects() {
           <span className="section-number">{"//"} 03</span>
           <h2 className="section-title">Projects</h2>
           <p className="section-subtitle">
-            A selection of things I've built — from production systems to side projects.
+            Grouped by project, with an overview and every repo that makes it up.
           </p>
         </div>
 
-        <div className="projects-grid">
-          {PROJECTS.map((project) => (
-            <div
-              key={project.slug}
-              className="project-card"
-              onClick={() => navigate(`/projects/${project.slug}`)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => e.key === 'Enter' && navigate(`/projects/${project.slug}`)}
-            >
-              <div className="project-card-top">
-                <span className="project-icon"><IconCode /></span>
-                <a
-                  href={project.github}
-                  className="proj-link"
-                  title="View on GitHub"
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <IconGitHub />
-                </a>
-              </div>
+        <div className="project-groups">
+          {PROJECT_GROUPS.map((group) => {
+            const Icon = ICONS[group.icon];
+            return (
+              <article key={group.name} className="project-group">
+                <div className="pg-head">
+                  <span className="pg-icon">{Icon && <Icon />}</span>
+                  <div className="pg-heading">
+                    <h3 className="pg-name">{group.name}</h3>
+                    <p className="pg-tagline">{group.tagline}</p>
+                  </div>
+                  {group.repos.length > 0 && (
+                    <div className="pg-repos-links">
+                      {group.repos.map((repo) => (
+                        <a
+                          key={repo.url}
+                          href={repo.url}
+                          className="pg-repo"
+                          target="_blank"
+                          rel="noreferrer"
+                          title="View repository on GitHub"
+                        >
+                          <IconGitHub />
+                          {repo.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
 
-              <h3 className="project-name">{project.name}</h3>
-              <p className="project-description">{project.overview[0]}</p>
+                <p className="pg-description">{group.description}</p>
 
-              <div className="project-stack">
-                {project.stack.map((tech) => (
-                  <span key={tech} className="tag">{tech}</span>
-                ))}
-              </div>
+                <div className="pg-stack">
+                  {group.stack.map((tech) => (
+                    <span key={tech} className="tag">{tech}</span>
+                  ))}
+                </div>
 
-              <span className="project-cta">View details →</span>
-            </div>
-          ))}
+                <div className="pg-parts">
+                  {group.parts.map((part) => (
+                    <div
+                      key={part.slug}
+                      className="part-card"
+                      onClick={() => navigate(`/projects/${part.slug}`)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => e.key === 'Enter' && navigate(`/projects/${part.slug}`)}
+                    >
+                      <div className="part-top">
+                        <span className="part-kind">{part.kind}</span>
+                        <a
+                          href={part.github}
+                          className="proj-link"
+                          title="View on GitHub"
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <IconGitHub />
+                        </a>
+                      </div>
+
+                      <p className="part-blurb">{part.blurb}</p>
+
+                      <div className="part-stack">
+                        {part.stack.map((tech) => (
+                          <span key={tech} className="tag sm">{tech}</span>
+                        ))}
+                      </div>
+
+                      <span className="part-cta">View details →</span>
+                    </div>
+                  ))}
+                </div>
+              </article>
+            );
+          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
- Add a PROJECT_GROUPS layer over the existing project entries
- Rebuild the Projects section as one panel per project: an icon (fuel pump / white cane), overview, combined stack, repo links, and a card per repo linking to GitHub and the detail page
- Reword descriptions to drop em-dashes